### PR TITLE
Changed internal agent configuration from static, enabling multi-agent config

### DIFF
--- a/S203.NewRelic.RabbitMq/RabbitAgent.cs
+++ b/S203.NewRelic.RabbitMq/RabbitAgent.cs
@@ -15,10 +15,10 @@ namespace S203.NewRelic.RabbitMq
         private static readonly Logger Logger = Logger.GetLogger("RabbitLogger");
         private readonly Version _version = Assembly.GetExecutingAssembly().GetName().Version;
         private readonly string _name;
-        private static string _host;
-        private static int _port;
-        private static string _username;
-        private static string _password;
+        private string _host;
+        private int _port;
+        private string _username;
+        private string _password;
 
         private readonly IProcessor _messagesPublished;
         private readonly IProcessor _messagesAcked;


### PR DESCRIPTION
Nice plugin @brentpabst - has worked fine with one agent/ElasticSearch server configured.
However it fails when adding multiple agent-configurations; it will push the same data into all instances in New Relic.

This is due to the fact the host config is static, making the last agent-config being the one used for all instances.

This tiny fix should remedy that. Hope you'll be able to accept and publish an update.
Since the host-config is internal, I didn't add any unit-tests.

Regards,
Espen Wang Andreassen